### PR TITLE
[WIRES] Make plugin compatible with wires refactor

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Maria Schuld
+Josh Izaac, Maria Schuld
 
 ---
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,9 @@ jobs:
           python setup.py bdist_wheel
           pip install dist/PennyLane*.whl
       - name: Run tests
-        run: python -m pytest tests -s --cov=pennylane_pq --cov-report=term-missing -p no:warnings --tb=native
+        env:
+          IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
+        run: python -m pytest tests --cov=pennylane_pq --cov-report=term-missing -p no:warnings --tb=native
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           python setup.py bdist_wheel
           pip install dist/PennyLane*.whl
       - name: Run tests
-        run: python -m pytest tests --cov=pennylane_pq --cov-report=term-missing -p no:warnings --tb=native
+        run: python -m pytest tests -s --cov=pennylane_pq --cov-report=term-missing -p no:warnings --tb=native
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/pennylane_pq/__init__.py
+++ b/pennylane_pq/__init__.py
@@ -14,8 +14,8 @@
 """ """
 from ._version import __version__
 
-from .devices import ProjectQSimulator #pylint: disable=unused-import
-from .devices import ProjectQIBMBackend #pylint: disable=unused-import
-from .devices import ProjectQClassicalSimulator #pylint: disable=unused-import
+from .devices import ProjectQSimulator  # pylint: disable=unused-import
+from .devices import ProjectQIBMBackend  # pylint: disable=unused-import
+from .devices import ProjectQClassicalSimulator  # pylint: disable=unused-import
 
-from .ops import * #pylint: disable=wildcard-import,unused-wildcard-import
+from .ops import *  # pylint: disable=wildcard-import,unused-wildcard-import

--- a/pennylane_pq/_version.py
+++ b/pennylane_pq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.9.0-dev'
+__version__ = "0.9.0-dev"

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -50,6 +50,7 @@ ProjectQClassicalSimulator
 import abc
 import numpy as np
 import projectq as pq
+from projectq.setups.ibm import get_engine_list
 from projectq.ops import (
     HGate,
     XGate,
@@ -536,7 +537,7 @@ class ProjectQIBMBackend(_ProjectQDevice):
         self._eng = pq.MainEngine(
             backend,
             verbose=self._kwargs["verbose"],
-            engine_list=pq.setups.ibm.get_engine_list(token=token, device=device),
+            engine_list=get_engine_list(token=token, device=device),
         )
         super().reset()
 

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -227,7 +227,7 @@ class _ProjectQDevice(Device):  # pylint: disable=abstract-method
             (
                 pq.ops._metagates.ControlledGate,  # pylint: disable=protected-access
                 pq.ops._gates.SqrtSwapGate,  # pylint: disable=protected-access
-                pq.ops._gates.SwapGate,
+                pq.ops._gates.SwapGate,  # pylint: disable=protected-access
             ),
         ):  # pylint: disable=protected-access
             qureg = tuple(qureg)
@@ -360,7 +360,7 @@ class ProjectQSimulator(_ProjectQDevice):
         """
         device_wires = self.map_wires(wires)
 
-        if observable == "PauliX" or observable == "PauliY" or observable == "PauliZ":
+        if observable in ["PauliX", "PauliY", "PauliZ"]:
             expval = self._eng.backend.get_expectation_value(
                 pq.ops.QubitOperator(str(observable)[-1] + "0"), [self._reg[device_wires.labels[0]]]
             )
@@ -521,8 +521,6 @@ class ProjectQIBMBackend(_ProjectQDevice):
                 'An IBM Quantum Experience token specified via the "token" keyword argument is required'
             )  # pylint: disable=line-too-long
 
-        import projectq.setups.ibm  # pylint: disable=unused-variable
-
         kwargs["backend"] = "IBMBackend"
         super().__init__(wires=wires, shots=shots, analytic=False, **kwargs)
 
@@ -572,12 +570,7 @@ class ProjectQIBMBackend(_ProjectQDevice):
 
         probabilities = self._eng.backend.get_probabilities(self._reg)
 
-        if (
-            observable == "PauliX"
-            or observable == "PauliY"
-            or observable == "PauliZ"
-            or observable == "Hadamard"
-        ):
+        if observable in ["PauliX", "PauliY", "PauliZ", "Hadamard"]:
 
             if observable != "PauliZ" and not hasattr(self, "obs_queue"):
                 raise DeviceError(
@@ -609,6 +602,7 @@ class ProjectQIBMBackend(_ProjectQDevice):
 
         elif observable == "Hermitian":
             raise NotImplementedError
+
         elif observable == "Identity":
             expval = sum(p for (state, p) in probabilities.items())
         # elif observable == 'AllPauliZ':

--- a/pennylane_pq/ops.py
+++ b/pennylane_pq/ops.py
@@ -40,7 +40,8 @@ quantum functions:
 
 import pennylane.operation as plops
 
-class S(plops.Operation): #pylint: disable=invalid-name,too-few-public-methods
+
+class S(plops.Operation):  # pylint: disable=invalid-name,too-few-public-methods
     r"""S gate.
 
     .. math:: S = \begin{bmatrix} 1 & 0 \\ 0 & i \end{bmatrix}
@@ -53,7 +54,7 @@ class S(plops.Operation): #pylint: disable=invalid-name,too-few-public-methods
     par_domain = None
 
 
-class T(plops.Operation): #pylint: disable=invalid-name,too-few-public-methods
+class T(plops.Operation):  # pylint: disable=invalid-name,too-few-public-methods
     r"""T gate.
 
     .. math:: T = \begin{bmatrix}1&0\\0&\exp(i \pi / 4)\end{bmatrix}
@@ -64,6 +65,7 @@ class T(plops.Operation): #pylint: disable=invalid-name,too-few-public-methods
     num_params = 0
     num_wires = 1
     par_domain = None
+
 
 class SqrtX(plops.Operation):
     r"""Square root X gate.
@@ -77,7 +79,8 @@ class SqrtX(plops.Operation):
     num_wires = 1
     par_domain = None
 
-class SqrtSwap(plops.Operation): #pylint: disable=too-few-public-methods
+
+class SqrtSwap(plops.Operation):  # pylint: disable=too-few-public-methods
     r"""Square root SWAP gate.
 
     .. math:: \mathrm{SqrtSwap} = \begin{bmatrix}1&0&0&0\\0&(1+i)/2&(1-i)/2&0\\
@@ -89,6 +92,7 @@ class SqrtSwap(plops.Operation): #pylint: disable=too-few-public-methods
     num_params = 0
     num_wires = 2
     par_domain = None
+
 
 # class Toffoli(Operation): #pylint: disable=too-few-public-methods
 #     r"""Apply the Tofoli gate.

--- a/pennylane_pq/pqops.py
+++ b/pennylane_pq/pqops.py
@@ -25,8 +25,10 @@ import projectq as pq
 from projectq.ops import BasicGate, SelfInverseGate
 import numpy as np
 
-class BasicProjectQGate(BasicGate): # pylint: disable=too-few-public-methods
+
+class BasicProjectQGate(BasicGate):  # pylint: disable=too-few-public-methods
     """Base class for ProjectQ gates."""
+
     def __init__(self, name="unnamed"):
         super().__init__()
         self.name = name
@@ -34,13 +36,16 @@ class BasicProjectQGate(BasicGate): # pylint: disable=too-few-public-methods
     def __str__(self):
         return self.name
 
+
 try:
-    from projectq.ops import MatrixGate #pylint: disable=ungrouped-imports
+    from projectq.ops import MatrixGate  # pylint: disable=ungrouped-imports
 except ImportError:
     MatrixGate = BasicGate
 
-class BasicProjectQMatrixGate(MatrixGate): # pylint: disable=too-few-public-methods
+
+class BasicProjectQMatrixGate(MatrixGate):  # pylint: disable=too-few-public-methods
     """Base class for ProjectQ gates defined via a matrix."""
+
     def __init__(self, name="unnamed"):
         super().__init__()
         self.name = name
@@ -48,7 +53,8 @@ class BasicProjectQMatrixGate(MatrixGate): # pylint: disable=too-few-public-meth
     def __str__(self):
         return self.name
 
-class CNOT(BasicProjectQGate): # pylint: disable=too-few-public-methods
+
+class CNOT(BasicProjectQGate):  # pylint: disable=too-few-public-methods
     """Class for the CNOT gate.
 
     Contrary to other gates, ProjectQ does not have a class for the CNOT gate,
@@ -56,10 +62,12 @@ class CNOT(BasicProjectQGate): # pylint: disable=too-few-public-methods
     For consistency we define this class, whose constructor is made to retun
     a gate with the correct properties by overwriting __new__().
     """
-    def __new__(*par): # pylint: disable=no-method-argument
+
+    def __new__(*par):  # pylint: disable=no-method-argument
         return pq.ops.C(pq.ops.XGate())
 
-class CZ(BasicProjectQGate): # pylint: disable=too-few-public-methods
+
+class CZ(BasicProjectQGate):  # pylint: disable=too-few-public-methods
     """Class for the CNOT gate.
 
     Contrary to other gates, ProjectQ does not have a class for the CZ gate,
@@ -67,8 +75,10 @@ class CZ(BasicProjectQGate): # pylint: disable=too-few-public-methods
     For consistency we define this class, whose constructor is made to retun
     a gate with the correct properties by overwriting __new__().
     """
-    def __new__(*par): # pylint: disable=no-method-argument
+
+    def __new__(*par):  # pylint: disable=no-method-argument
         return pq.ops.C(pq.ops.ZGate())
+
 
 # class Toffoli(BasicProjectQGate): # pylint: disable=too-few-public-methods
 #     """Class for the Toffoli gate.
@@ -92,6 +102,7 @@ class CZ(BasicProjectQGate): # pylint: disable=too-few-public-methods
 #     def __new__(*par): # pylint: disable=no-method-argument
 #         return pq.ops.Tensor(pq.ops.ZGate())
 
+
 class Rot(BasicProjectQGate):
     """Class for the arbitrary single qubit rotation gate.
 
@@ -99,21 +110,23 @@ class Rot(BasicProjectQGate):
     so we provide a class that return a suitable combination of rotation gates
     assembled into a single gate from the constructor of this class.
     """
+
     def __init__(self, *par):
         BasicProjectQGate.__init__(self, name=self.__class__.__name__)
         self.angles = par
 
     def __or__(self, qubits):
-        pq.ops.Rz(self.angles[0]) | qubits #pylint: disable=expression-not-assigned
-        pq.ops.Ry(self.angles[1]) | qubits #pylint: disable=expression-not-assigned
-        pq.ops.Rz(self.angles[2]) | qubits #pylint: disable=expression-not-assigned
+        pq.ops.Rz(self.angles[0]) | qubits  # pylint: disable=expression-not-assigned
+        pq.ops.Ry(self.angles[1]) | qubits  # pylint: disable=expression-not-assigned
+        pq.ops.Rz(self.angles[2]) | qubits  # pylint: disable=expression-not-assigned
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
             return self.angles == other.angles
         return False
 
-class QubitUnitary(BasicProjectQGate): # pylint: disable=too-few-public-methods
+
+class QubitUnitary(BasicProjectQGate):  # pylint: disable=too-few-public-methods
     """Class for the QubitUnitary gate.
 
     ProjectQ does not currently have a real arbitrary QubitUnitary gate,
@@ -121,16 +134,19 @@ class QubitUnitary(BasicProjectQGate): # pylint: disable=too-few-public-methods
     can then still decompose them into the elementary gates set, so we
     do this here.
     """
+
     def __new__(*par):
         unitary_gate = BasicProjectQMatrixGate(par[0].__name__)
         unitary_gate.matrix = np.array(par[1])
         return unitary_gate
 
-class BasisState(BasicProjectQGate, SelfInverseGate): # pylint: disable=too-few-public-methods
+
+class BasisState(BasicProjectQGate, SelfInverseGate):  # pylint: disable=too-few-public-methods
     """Class for the BasisState preparation.
 
     ProjectQ does not currently have a dedicated gate for this, so we implement it here.
     """
+
     def __init__(self, basis_state_to_prep):
         BasicProjectQGate.__init__(self, name=self.__class__.__name__)
         SelfInverseGate.__init__(self)
@@ -139,7 +155,7 @@ class BasisState(BasicProjectQGate, SelfInverseGate): # pylint: disable=too-few-
     def __or__(self, qubits):
         for i, qureg in enumerate(qubits):
             if self.basis_state_to_prep[i] == 1:
-                pq.ops.XGate() | qureg #pylint: disable=expression-not-assigned
+                pq.ops.XGate() | qureg  # pylint: disable=expression-not-assigned
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/ProjectQ-Framework/ProjectQ.git#egg=projectq
-pennylane>=0.6
+projectq>=0.5.1
+pennylane>=0.11.0dev
 pybind11

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("pennylane_pq/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")  # pylint: disable=invalid-name
 
 
-requirements = ["projectq>=0.4.1", "pennylane>=0.6"]  # pylint: disable=invalid-name
+requirements = ["projectq>=0.5.1", "pennylane>=0.6"]  # pylint: disable=invalid-name
 
 
 info = {  # pylint: disable=invalid-name

--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -17,15 +17,9 @@ Unit tests for the :mod:`pennylane_pq` BasisState operation.
 
 import unittest
 import logging as log
-#import inspect
-#from unittest_data_provider import data_provider
-#from pkg_resources import iter_entry_points
 from defaults import pennylane as qml, BaseTest
 import pennylane
-#from pennylane import Device
 from pennylane import numpy as np
-import pennylane_pq
-import pennylane_pq.expval
 from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, ProjectQIBMBackend
 
 log.getLogger('defaults')

--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -47,7 +47,7 @@ class BasisStateTest(BaseTest):
         if self.args.device == 'ibm' or self.args.device == 'all':
             ibm_options = pennylane.default_config['projectq.ibm']
             if "user" in ibm_options and "password" in ibm_options:
-                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, user=ibm_options['user'], password=ibm_options['password'], verbose=True))
+                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, token=ibm_options['token'], verbose=True))
             else:
                 log.warning("Skipping test of the ProjectQIBMBackend device because IBM login credentials could not be found in the PennyLane configuration file.")
         if self.args.device == 'classical' or self.args.device == 'all':

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -17,11 +17,7 @@ Unit tests for the :mod:`pennylane_pq` devices.
 
 import unittest
 import logging as log
-#import inspect
-#from unittest_data_provider import data_provider
-from pkg_resources import iter_entry_points
 from defaults import pennylane as qml, BaseTest
-from pennylane import Device
 from pennylane import numpy as np
 from pennylane.devices.default_qubit import DefaultQubit
 import pennylane

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -23,7 +23,7 @@ from pkg_resources import iter_entry_points
 from defaults import pennylane as qml, BaseTest
 from pennylane import Device
 from pennylane import numpy as np
-from pennylane.plugins.default_qubit import DefaultQubit
+from pennylane.devices.default_qubit import DefaultQubit
 import pennylane
 import pennylane_pq
 import pennylane_pq.expval
@@ -49,7 +49,7 @@ class CompareWithDefaultQubitTest(BaseTest):
         if self.args.device == 'ibm' or self.args.device == 'all':
             ibm_options = pennylane.default_config['projectq.ibm']
             if "user" in ibm_options and "password" in ibm_options:
-                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, user=ibm_options['user'], password=ibm_options['password'], verbose=True))
+                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, token=ibm_options['token'], verbose=True))
             else:
                 log.warning("Skipping test of the ProjectQIBMBackend device because IBM login credentials could not be found in the PennyLane configuration file.")
         if self.args.device == 'classical' or self.args.device == 'all':

--- a/tests/test_device_initialization.py
+++ b/tests/test_device_initialization.py
@@ -17,22 +17,13 @@ Unit tests for the :mod:`pennylane_pq` device initialization
 
 import unittest
 import logging as log
-#import inspect
-#from unittest_data_provider import data_provider
-from pkg_resources import iter_entry_points
 from defaults import pennylane as qml, BaseTest
-import pennylane
-from pennylane import Device, DeviceError
-from pennylane import numpy as np
-import pennylane_pq
-import pennylane_pq.expval
-from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, ProjectQIBMBackend
+from pennylane import DeviceError
+from pennylane_pq.devices import ProjectQIBMBackend
 import os
 
-token = os.environ.get("IBMQX_TOKEN", "")
-
+token = os.getenv("IBMQX_TOKEN")
 log.getLogger('defaults')
-
 
 
 class DeviceInitialization(BaseTest):

--- a/tests/test_device_initialization.py
+++ b/tests/test_device_initialization.py
@@ -38,24 +38,20 @@ class DeviceInitialization(BaseTest):
     num_subsystems = 4
     devices = None
 
-    def test_ibm_no_user(self):
+    def test_ibm_no_token(self):
         if self.args.device == 'ibm' or self.args.device == 'all':
-            self.assertRaises(ValueError, ProjectQIBMBackend, wires=self.num_subsystems, use_hardware=False, password='password')
-
-    def test_ibm_no_password(self):
-        if self.args.device == 'ibm' or self.args.device == 'all':
-            self.assertRaises(ValueError, ProjectQIBMBackend, wires=self.num_subsystems, use_hardware=False, user='user')
+            self.assertRaises(ValueError, ProjectQIBMBackend, wires=self.num_subsystems, use_hardware=False)
 
     def test_shots(self):
         if self.args.device == 'ibm' or self.args.device == 'all':
             shots = 5
-            dev1 = ProjectQIBMBackend(wires=self.num_subsystems, shots=shots, use_hardware=False, user="user", password='password')
+            dev1 = ProjectQIBMBackend(wires=self.num_subsystems, shots=shots, use_hardware=False, token='token')
             self.assertEqual(shots, dev1.shots)
 
-            dev2 = ProjectQIBMBackend(wires=self.num_subsystems, num_runs=shots, use_hardware=False, user="user", password='password')
+            dev2 = ProjectQIBMBackend(wires=self.num_subsystems, num_runs=shots, use_hardware=False, token='token')
             self.assertEqual(shots, dev2.shots)
 
-            dev2 = ProjectQIBMBackend(wires=self.num_subsystems, shots=shots+2, num_runs=shots, use_hardware=False, user="user", password='password')
+            dev2 = ProjectQIBMBackend(wires=self.num_subsystems, shots=shots+2, num_runs=shots, use_hardware=False, token='token')
             self.assertEqual(shots, dev2.shots)
 
     def test_initiatlization_via_pennylane(self):
@@ -65,9 +61,10 @@ class DeviceInitialization(BaseTest):
                 'projectq.ibm'
         ]:
             try:
-                dev = dev = qml.device(short_name, wires=2, user='user', password='password', verbose=True)
+                dev = qml.device(short_name, wires=2, token='token', verbose=True)
             except DeviceError:
                 raise Exception("This test is expected to fail until pennylane-pq is installed.")
+
 
 if __name__ == '__main__':
     print('Testing PennyLane ProjectQ Plugin version ' + qml.version() + ', device initialization.')

--- a/tests/test_device_initialization.py
+++ b/tests/test_device_initialization.py
@@ -66,11 +66,7 @@ class DeviceInitialization(BaseTest):
                 'projectq.ibm'
         ]:
             try:
-<<<<<<< HEAD
-                dev = qml.device(short_name, wires=2, token='token', verbose=True)
-=======
                 dev = qml.device(short_name, wires=2, token=token, verbose=True)
->>>>>>> fix_user_bug
             except DeviceError:
                 raise Exception("This test is expected to fail until pennylane-pq is installed.")
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -18,18 +18,13 @@ Unit tests for the :mod:`pennylane_pq` device documentation
 import unittest
 import logging as log
 import re
-from pkg_resources import iter_entry_points
 from defaults import pennylane as qml, BaseTest
-import pennylane
-from pennylane import Device, DeviceError
-from pennylane import numpy as np
-import pennylane_pq
-import pennylane_pq.expval
 from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, ProjectQIBMBackend
 import os
 
-token = os.environ.get("IBMQX_TOKEN", "")
+token = os.getenv("IBMQX_TOKEN")
 log.getLogger('defaults')
+
 
 class DocumentationTest(BaseTest):
     """test documentation of the plugin.

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -47,9 +47,9 @@ class DocumentationTest(BaseTest):
         if self.args.device == 'ibm' or self.args.device == 'all':
             ibm_options = pennylane.default_config['projectq.ibm']
             if "user" in ibm_options and "password" in ibm_options:
-                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, user=ibm_options['user'], password=ibm_options['password']))
+                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, token=ibm_options['token']))
             else:
-                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, user='user', password='password'))
+                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, token='token'))
         if self.args.device == 'classical' or self.args.device == 'all':
             self.devices.append(ProjectQClassicalSimulator(wires=self.num_subsystems))
 

--- a/tests/test_ibm_expval_and_pre_expval_mock.py
+++ b/tests/test_ibm_expval_and_pre_expval_mock.py
@@ -17,20 +17,16 @@ Unit tests for the :mod:`pennylane_pq` device documentation
 
 import unittest
 import logging as log
-import re
-from pkg_resources import iter_entry_points
 from defaults import pennylane as qml, BaseTest
-import pennylane
-from pennylane import Device, DeviceError
-from pennylane import numpy as np
-import pennylane_pq
-import pennylane_pq.expval
-from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, ProjectQIBMBackend
+from pennylane import DeviceError
+from pennylane.wires import Wires
+from pennylane_pq.devices import ProjectQIBMBackend
 from unittest.mock import patch, MagicMock, PropertyMock, call
 import os
 
-token = os.environ.get("IBMQX_TOKEN", "")
+token = os.getenv("IBMQX_TOKEN")
 log.getLogger('defaults')
+
 
 class ExpvalAndPreExpvalMock(BaseTest):
     """test pre_measure and expval of the plugin in a fake way that works without ibm credentials
@@ -76,7 +72,6 @@ class ExpvalAndPreExpvalMock(BaseTest):
             with patch('projectq.ops.All', new_callable=PropertyMock) as mock_All:
                 self.assertRaises(NotImplementedError, dev.pre_measure)
 
-
     def test_expval(self):
 
         dev = ProjectQIBMBackend(wires=2, use_hardware=False, num_runs=8*1024, token=token, verbose=True)
@@ -85,9 +80,9 @@ class ExpvalAndPreExpvalMock(BaseTest):
         dev._eng.backend.get_probabilities = MagicMock()
         dev._eng.backend.get_probabilities.return_value = {'00': 0.1, '01': 0.3, '10': 0.2, '11': 0.4}
 
-        self.assertAlmostEqual(dev.expval('PauliZ', wires=[0], par=list()), -0.2, delta=self.tol)
-        self.assertAlmostEqual(dev.expval('Identity', wires=[0], par=list()), 1.0, delta=self.tol)
-        self.assertRaises(NotImplementedError, dev.expval, 'Hermitian', wires=[0], par=list())
+        self.assertAlmostEqual(dev.expval('PauliZ', wires=Wires([0]), par=list()), -0.2, delta=self.tol)
+        self.assertAlmostEqual(dev.expval('Identity', wires=Wires([0]), par=list()), 1.0, delta=self.tol)
+        self.assertRaises(NotImplementedError, dev.expval, 'Hermitian', wires=Wires([0]), par=list())
 
 
 class Expval(BaseTest):
@@ -107,9 +102,9 @@ class Expval(BaseTest):
         dev._eng.backend.get_probabilities = MagicMock()
         dev._eng.backend.get_probabilities.return_value = {'00': 1.0}
 
-        self.assertRaises(DeviceError, dev.expval, 'PauliX', wires=[0], par=list())
-        self.assertRaises(DeviceError, dev.expval, 'PauliY', wires=[0], par=list())
-        self.assertRaises(DeviceError, dev.expval, 'Hadamard', wires=[0], par=list())
+        self.assertRaises(DeviceError, dev.expval, 'PauliX', wires=Wires([0]), par=list())
+        self.assertRaises(DeviceError, dev.expval, 'PauliY', wires=Wires([0]), par=list())
+        self.assertRaises(DeviceError, dev.expval, 'Hadamard', wires=Wires([0]), par=list())
 
 if __name__ == '__main__':
     print('Testing PennyLane ProjectQ Plugin version ' + qml.version() + ', device expval and pre_measure.')

--- a/tests/test_ibm_expval_and_pre_expval_mock.py
+++ b/tests/test_ibm_expval_and_pre_expval_mock.py
@@ -51,7 +51,7 @@ class ExpvalAndPreExpvalMock(BaseTest):
                 mock_PauliY,
                 mock_Hadamard,
             ]
-            dev = ProjectQIBMBackend(wires=2, use_hardware=False, num_runs=8*1024, user='user', password='password', verbose=True)
+            dev = ProjectQIBMBackend(wires=2, use_hardware=False, num_runs=8*1024, token='token', verbose=True)
             dev._eng = MagicMock()
             dev.apply = MagicMock()
 
@@ -77,7 +77,7 @@ class ExpvalAndPreExpvalMock(BaseTest):
 
     def test_expval(self):
 
-        dev = ProjectQIBMBackend(wires=2, use_hardware=False, num_runs=8*1024, user='user', password='password', verbose=True)
+        dev = ProjectQIBMBackend(wires=2, use_hardware=False, num_runs=8*1024, token='token', verbose=True)
         dev._eng = MagicMock()
         dev._eng.backend = MagicMock()
         dev._eng.backend.get_probabilities = MagicMock()
@@ -95,7 +95,7 @@ class Expval(BaseTest):
     def test_expval_exception_if_no_obs_queue(self):
 
         if self.args.device == 'ibm' or self.args.device == 'all':
-            dev = ProjectQIBMBackend(wires=2, shots=1, use_hardware=False, user='user', password='password', verbose=True)
+            dev = ProjectQIBMBackend(wires=2, shots=1, use_hardware=False, token='token', verbose=True)
         else:
             return
 

--- a/tests/test_projectq_import.py
+++ b/tests/test_projectq_import.py
@@ -24,6 +24,7 @@ from defaults import pennylane as qml, BaseTest
 
 log.getLogger('defaults')
 
+
 class ProjectQImportTest(BaseTest):
     """test of projectq import.
     """

--- a/tests/test_unsupported_operations.py
+++ b/tests/test_unsupported_operations.py
@@ -47,7 +47,7 @@ class UnsupportedOperationTest(BaseTest):
         if self.args.device == 'ibm' or self.args.device == 'all':
             ibm_options = pennylane.default_config['projectq.ibm']
             if "user" in ibm_options and "password" in ibm_options:
-                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, user=ibm_options['user'], password=ibm_options['password'], verbose=True))
+                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, token=ibm_options['token'], verbose=True))
             else:
                 log.warning("Skipping test of the ProjectQIBMBackend device because IBM login credentials could not be found in the PennyLane configuration file.")
         if self.args.device == 'classical' or self.args.device == 'all':

--- a/tests/test_unsupported_operations.py
+++ b/tests/test_unsupported_operations.py
@@ -17,15 +17,8 @@ Unit tests for the :mod:`pennylane_pq` devices' behavior when applying unsupport
 
 import unittest
 import logging as log
-#import inspect
-#from unittest_data_provider import data_provider
-from pkg_resources import iter_entry_points
 from defaults import pennylane as qml, BaseTest
 import pennylane
-from pennylane import Device
-from pennylane import numpy as np
-import pennylane_pq
-import pennylane_pq.expval
 from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, ProjectQIBMBackend
 
 log.getLogger('defaults')

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -26,7 +26,7 @@ from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, 
 import os
 
 token = os.getenv("IBMQX_TOKEN")
-print("Token", token)
+print("Token here hello", token)
 
 
 @pytest.fixture

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -26,7 +26,6 @@ from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, 
 import os
 
 token = os.getenv("IBMQX_TOKEN")
-print("Token here hello", token)
 
 
 @pytest.fixture

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -19,6 +19,7 @@ import pytest
 
 import numpy as np
 import pennylane
+from pennylane.wires import Wires
 
 from defaults import TOLERANCE
 from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, ProjectQIBMBackend
@@ -45,8 +46,7 @@ def dev(DevClass, monkeypatch):
             wires=1,
             use_hardware=False,
             num_runs=8 * 1024,
-            user="user",
-            password="password",
+            token="token",
             verbose=True,
         )
 
@@ -66,14 +66,14 @@ def dev(DevClass, monkeypatch):
 )
 def test_var_pauliz(dev, tol):
     """Test that variance of PauliZ is the same as I-<Z>^2"""
-    dev.apply("PauliX", wires=[0], par=[])
+    dev.apply("PauliX", wires=Wires([0]), par=[])
 
     if isinstance(dev, ProjectQIBMBackend):
         dev._eng.backend.get_probabilities.return_value = {"0": 0, "1": 1}
 
     dev.pre_measure()
-    var = dev.var("PauliZ", wires=[0], par=[])
-    mean = dev.expval("PauliZ", wires=[0], par=[])
+    var = dev.var("PauliZ", wires=Wires([0]), par=[])
+    mean = dev.expval("PauliZ", wires=Wires([0]), par=[])
     dev.post_measure()
 
     assert np.allclose(var, 1 - mean ** 2, atol=tol, rtol=0)
@@ -85,8 +85,8 @@ def test_var_pauliz_rotated_state(dev, tol):
     phi = 0.543
     theta = 0.6543
 
-    dev.apply("RX", wires=[0], par=[phi])
-    dev.apply("RY", wires=[0], par=[theta])
+    dev.apply("RX", wires=Wires([0]), par=[phi])
+    dev.apply("RY", wires=Wires([0]), par=[theta])
 
     if isinstance(dev, ProjectQIBMBackend):
         dev._eng.backend.get_probabilities.return_value = {
@@ -95,7 +95,7 @@ def test_var_pauliz_rotated_state(dev, tol):
         }
 
     dev.pre_measure()
-    var = dev.var("PauliZ", wires=[0], par=[])
+    var = dev.var("PauliZ", wires=Wires([0]), par=[])
     dev.post_measure()
     expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
 

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -25,7 +25,7 @@ from defaults import TOLERANCE
 from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, ProjectQIBMBackend
 import os
 
-token = os.environ.get("IBMQX_TOKEN", "")
+token = os.getenv("IBMQX_TOKEN")
 
 
 @pytest.fixture

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -26,6 +26,7 @@ from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, 
 import os
 
 token = os.getenv("IBMQX_TOKEN")
+print("Token", token)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR updates the plugin to support the new wire management in PennyLane master.

It contains all changes from PR #62, which are now difficult to test due to the new wires management.