### PR TITLE
Remove analytic keyword argument and v0.15 version bump

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,7 +6,7 @@
 * For compatibility with PennyLane v0.15, the `analytic` keyword argument
   has been removed from all devices. Analytic expectation values can
   still be computed by setting `shots=None`.
-  [(#)]()
+  [(#69)](https://github.com/XanaduAI/pennylane-pq/pull/69)
 
 This release contains contributions from (in alphabetical order):
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,8 @@
   still be computed by setting `shots=None`.
   [(#69)](https://github.com/XanaduAI/pennylane-pq/pull/69)
 
+### Contributors
+
 This release contains contributions from (in alphabetical order):
 
 Josh Izaac

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,18 +1,16 @@
-# Release 0.15.0-dev
+# Release 0.15.0
 
-### New features since last release
 
 ### Breaking changes
 
-### Improvements
-
-### Documentation
-
-### Bug fixes
-
-### Contributors
+* For compatibility with PennyLane v0.15, the `analytic` keyword argument
+  has been removed from all devices. Analytic expectation values can
+  still be computed by setting `shots=None`.
+  [(#)]()
 
 This release contains contributions from (in alphabetical order):
+
+Josh Izaac
 
 ---
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,9 @@ jobs:
         uses: styfle/cancel-workflow-action@0.4.1
         with:
           access_token: ${{ github.token }}
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -35,6 +37,6 @@ jobs:
           IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
         run: python -m pytest tests --cov=pennylane_pq --cov-report=term-missing -p no:warnings --tb=native
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1.0.12
         with:
           file: ./.coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Run tests
         env:
           IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN }}
-        run: python -m pytest tests --cov=pennylane_pq --cov-report=term-missing -p no:warnings --tb=native
+        run: python -m pytest tests --cov=pennylane_pq --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.12
         with:
-          file: ./.coverage
+          file: ./coverage.xml

--- a/doc/xanadu_theme/header.html
+++ b/doc/xanadu_theme/header.html
@@ -33,10 +33,13 @@
       </li>
       <li class="nav-item active">
         <a class="nav-link" href="https://pennylane.ai/plugins.html">Plugins</a>
+          <span class="sr-only">(current)</span>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="https://pennylane.readthedocs.io">Documentation</a>
-          <span class="sr-only">(current)</span>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="https://pennylane.ai/blog">Blog</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="https://qhack.ai"><img src="https://pennylane.ai/img/qhack_plain_black.png"></a>

--- a/doc/xanadu_theme/layout.html
+++ b/doc/xanadu_theme/layout.html
@@ -3,6 +3,7 @@
 {# Do this so that bootstrap is included before the main css file #}
 {%- block htmltitle %}
   <link href="https://fonts.googleapis.com/css?family=Noto+Serif" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
 
   <!-- Font Awesome -->

--- a/doc/xanadu_theme/static/xanadu.css_t
+++ b/doc/xanadu_theme/static/xanadu.css_t
@@ -1,14 +1,5 @@
 /* Sphinx themes
 -------------------------------------------------- */
-@font-face {
-  font-family: 'Product Sans';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/productsans/v5/HYvgU2fE2nRJvZ5JFAumwegdm0LZdjqr5-oayXSOefg.woff2) format('woff2');
-}
-
-
-
 body {
   /*background-color: #edf0f2;*/
   margin: 0;
@@ -92,7 +83,7 @@ h1, h2, h3, h4, h5, h6 {
   color: black;
   font-weight: normal;
   padding: 0;
-  font-family: 'Product Sans', 'Roboto', sans-serif!important;
+  font-family: 'Noto Sans', 'Roboto', sans-serif!important;
 }
 
 h1, h2, h3 {
@@ -371,7 +362,7 @@ div.sphinxsidebar p {
   margin: 20px 0px 10px 21px;
   font-weight: normal;
   padding: 0;
-  font-family: 'Product Sans', 'Roboto', sans-serif!important;
+  font-family: 'Noto Sans', 'Roboto', sans-serif!important;
   font-size: 24px;
   color: #515151;
   /*text-align: center;*/
@@ -2012,7 +2003,7 @@ footer.page-footer .footer-copyright {
     margin-left: 20px;
     font-size: initial;
     color: black;
-    font-family: 'Product Sans', 'Roboto', sans-serif !important;
+    font-family: 'Noto Sans', 'Roboto', sans-serif !important;
     margin-bottom: -9px;
     border-bottom: 3px solid;
     border-bottom-color: white;

--- a/pennylane_pq/_version.py
+++ b/pennylane_pq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.15.0-dev"
+__version__ = "0.15.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 projectq>=0.5.1
-pennylane>=0.11
+git+https://github.com/PennyLaneAI/pennylane.git
 pybind11

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,10 @@ with open("pennylane_pq/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")  # pylint: disable=invalid-name
 
 
-requirements = ["projectq>=0.5.1", "git+https://github.com/PennyLaneAI/pennylane.git"]  # pylint: disable=invalid-name
+requirements = [
+    "projectq>=0.5.1",
+    "pennylane @ git+ssh://git@github.com/PennyLaneAI/pennylane#egg=pennylane"
+]  # pylint: disable=invalid-name
 
 
 info = {  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("pennylane_pq/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")  # pylint: disable=invalid-name
 
 
-requirements = ["projectq>=0.5.1", "pennylane>=0.11"]  # pylint: disable=invalid-name
+requirements = ["projectq>=0.5.1", "git+https://github.com/PennyLaneAI/pennylane.git"]  # pylint: disable=invalid-name
 
 
 info = {  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("pennylane_pq/_version.py") as f:
 
 requirements = [
     "projectq>=0.5.1",
-    "pennylane @ git+ssh://git@github.com/PennyLaneAI/pennylane#egg=pennylane"
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git#egg=pennylane"
 ]  # pylint: disable=invalid-name
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("pennylane_pq/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")  # pylint: disable=invalid-name
 
 
-requirements = ["projectq>=0.5.1", "pennylane>=0.15"]  # pylint: disable=invalid-name
+requirements = ["projectq>=0.5.1", "pennylane>=0.11"]  # pylint: disable=invalid-name
 
 
 info = {  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("pennylane_pq/_version.py") as f:
 
 requirements = [
     "projectq>=0.5.1",
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git#egg=pennylane"
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master"
 ]  # pylint: disable=invalid-name
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("pennylane_pq/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")  # pylint: disable=invalid-name
 
 
-requirements = ["projectq>=0.5.1", "pennylane>=0.11"]  # pylint: disable=invalid-name
+requirements = ["projectq>=0.5.1", "pennylane>=0.15"]  # pylint: disable=invalid-name
 
 
 info = {  # pylint: disable=invalid-name

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -16,6 +16,7 @@ Unit tests for the :mod:`pennylane_pq` devices.
 """
 
 import unittest
+import pytest
 import logging as log
 from defaults import pennylane as qml, BaseTest
 from pennylane import numpy as np

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -16,7 +16,6 @@ Unit tests for the :mod:`pennylane_pq` devices.
 """
 
 import unittest
-import pytest
 import logging as log
 from defaults import pennylane as qml, BaseTest
 from pennylane import numpy as np
@@ -92,9 +91,11 @@ class CompareWithDefaultQubitTest(BaseTest):
                             observable_class = getattr(pennylane_pq.expval, observable)
 
                         if operation_class.num_wires > self.num_subsystems:
-                            pytest.skip('Skipping in automatic test because the operation '+operation+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
+                            # raise IgnoreOperationException('Skipping in automatic test because the operation '+operation+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
+                            continue
                         if observable_class.num_wires > self.num_subsystems:
-                            pytest.skip('Skipping in automatic test because the observable '+observable+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
+                            # raise IgnoreOperationException('Skipping in automatic test because the observable '+observable+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
+                            continue
 
                         if operation_class.par_domain == 'N':
                             operation_pars = rnd_int_pool[:operation_class.num_params]
@@ -109,7 +110,8 @@ class CompareWithDefaultQubitTest(BaseTest):
                                 operation_pars = [random_zero_one_pool[:self.num_subsystems]]
                                 operation_class.num_wires = self.num_subsystems
                             else:
-                                pytest.skip('Skipping in automatic test because I don\'t know how to generate parameters for the operation '+operation)
+                                # raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the operation '+operation)
+                                continue
                         else:
                             operation_pars = {}
 
@@ -121,7 +123,8 @@ class CompareWithDefaultQubitTest(BaseTest):
                             if str(observable) == "Hermitian":
                                 observable_pars = [np.array([[1,1j],[-1j,0]])]
                             else:
-                                pytest.skip('Skipping in automatic test because I don\'t know how to generate parameters for the observable '+observable+" with par_domain="+str(observable_class.par_domain))
+                                # raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the observable '+observable+" with par_domain="+str(observable_class.par_domain))
+                                continue
                         else:
                             observable_pars = {}
 

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -91,11 +91,9 @@ class CompareWithDefaultQubitTest(BaseTest):
                             observable_class = getattr(pennylane_pq.expval, observable)
 
                         if operation_class.num_wires > self.num_subsystems:
-                            # raise IgnoreOperationException('Skipping in automatic test because the operation '+operation+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
-                            continue
+                            raise IgnoreOperationException('Skipping in automatic test because the operation '+operation+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
                         if observable_class.num_wires > self.num_subsystems:
-                            # raise IgnoreOperationException('Skipping in automatic test because the observable '+observable+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
-                            continue
+                            raise IgnoreOperationException('Skipping in automatic test because the observable '+observable+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
 
                         if operation_class.par_domain == 'N':
                             operation_pars = rnd_int_pool[:operation_class.num_params]
@@ -110,8 +108,7 @@ class CompareWithDefaultQubitTest(BaseTest):
                                 operation_pars = [random_zero_one_pool[:self.num_subsystems]]
                                 operation_class.num_wires = self.num_subsystems
                             else:
-                                # raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the operation '+operation)
-                                continue
+                                raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the operation '+operation)
                         else:
                             operation_pars = {}
 
@@ -123,8 +120,7 @@ class CompareWithDefaultQubitTest(BaseTest):
                             if str(observable) == "Hermitian":
                                 observable_pars = [np.array([[1,1j],[-1j,0]])]
                             else:
-                                # raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the observable '+observable+" with par_domain="+str(observable_class.par_domain))
-                                continue
+                                raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the observable '+observable+" with par_domain="+str(observable_class.par_domain))
                         else:
                             observable_pars = {}
 
@@ -138,7 +134,11 @@ class CompareWithDefaultQubitTest(BaseTest):
                         operation_class(*operation_pars, wires=operation_wires)
                         return qml.expval(observable_class(*observable_pars, wires=observable_wires))
 
-                    output = circuit()
+                    try:
+                        output = circuit()
+                    except IgnoreOperationException:
+                        continue
+
                     if (operation, observable) not in outputs:
                         outputs[(operation, observable)] = {}
 

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -91,9 +91,9 @@ class CompareWithDefaultQubitTest(BaseTest):
                             observable_class = getattr(pennylane_pq.expval, observable)
 
                         if operation_class.num_wires > self.num_subsystems:
-                            raise IgnoreOperationException('Skipping in automatic test because the operation '+operation+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
+                            pytest.skip('Skipping in automatic test because the operation '+operation+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
                         if observable_class.num_wires > self.num_subsystems:
-                            raise IgnoreOperationException('Skipping in automatic test because the observable '+observable+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
+                            pytest.skip('Skipping in automatic test because the observable '+observable+" acts on more than the default number of wires "+str(self.num_subsystems)+". Maybe you want to increase that?")
 
                         if operation_class.par_domain == 'N':
                             operation_pars = rnd_int_pool[:operation_class.num_params]
@@ -108,7 +108,7 @@ class CompareWithDefaultQubitTest(BaseTest):
                                 operation_pars = [random_zero_one_pool[:self.num_subsystems]]
                                 operation_class.num_wires = self.num_subsystems
                             else:
-                                raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the operation '+operation)
+                                pytest.skip('Skipping in automatic test because I don\'t know how to generate parameters for the operation '+operation)
                         else:
                             operation_pars = {}
 
@@ -120,7 +120,7 @@ class CompareWithDefaultQubitTest(BaseTest):
                             if str(observable) == "Hermitian":
                                 observable_pars = [np.array([[1,1j],[-1j,0]])]
                             else:
-                                raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the observable '+observable+" with par_domain="+str(observable_class.par_domain))
+                                pytest.skip('Skipping in automatic test because I don\'t know how to generate parameters for the observable '+observable+" with par_domain="+str(observable_class.par_domain))
                         else:
                             observable_pars = {}
 


### PR DESCRIPTION
For compatibility with PennyLane v0.15, the `analytic` keyword argument has been removed from all devices. Analytic expectation values can still be computed by setting `shots=None`.