### PR TITLE
Remove `SparseHamiltonian` from possible observables in test

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Bug fixes
 
 * Remove `SparseHamiltonian` from possible observables in test.
-  [(#70)](https://github.com/XanaduAI/pennylane-pq/pull/70)
+  [(#71)](https://github.com/XanaduAI/pennylane-pq/pull/71)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,9 +10,14 @@
 
 ### Bug fixes
 
+* Remove `SparseHamiltonian` from possible observables in test.
+  [(#70)](https://github.com/XanaduAI/pennylane-pq/pull/70)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Romain Moyard
 
 ---
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,9 @@ classifiers = [  # pylint: disable=invalid-name
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -68,9 +68,7 @@ class CompareWithDefaultQubitTest(BaseTest):
         random_ket = np.random.uniform(-1,1,2**self.num_subsystems)
         random_ket = random_ket / np.linalg.norm(random_ket)
         random_zero_one_pool = np.random.randint(2, size=100)
-
         for dev in self.devices:
-
             # run all single operation circuits
             for operation in dev.operations:
                 if operation in ("DiagonalQubitUnitary"):
@@ -121,6 +119,8 @@ class CompareWithDefaultQubitTest(BaseTest):
                                 observable_pars = [np.array([[1,1j],[-1j,0]])]
                             else:
                                 raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the observable '+observable+" with par_domain="+str(observable_class.par_domain))
+                        elif observable_class.par_domain == None:
+                            raise IgnoreOperationException('Skipping in automatic test because' + observable + " with par_domain=" + str(observable_class.par_domain) + 'is not valid in ProjectQ.')
                         else:
                             observable_pars = {}
 

--- a/tests/test_device_initialization.py
+++ b/tests/test_device_initialization.py
@@ -40,6 +40,8 @@ class DeviceInitialization(BaseTest):
     def test_shots(self):
         if self.args.device == 'ibm' or self.args.device == 'all':
             shots = 5
+            print(os.getenv("IBMQX_TOKEN"))
+            print(token)
             dev1 = ProjectQIBMBackend(wires=self.num_subsystems, shots=shots, use_hardware=False, token=token, verbose=True)
             self.assertEqual(shots, dev1.shots)
 

--- a/tests/test_device_initialization.py
+++ b/tests/test_device_initialization.py
@@ -40,8 +40,8 @@ class DeviceInitialization(BaseTest):
     def test_shots(self):
         if self.args.device == 'ibm' or self.args.device == 'all':
             shots = 5
-            print(os.getenv("IBMQX_TOKEN"))
-            print(token)
+            print("Token env", os.getenv("IBMQX_TOKEN"))
+            print("Token var", token)
             dev1 = ProjectQIBMBackend(wires=self.num_subsystems, shots=shots, use_hardware=False, token=token, verbose=True)
             self.assertEqual(shots, dev1.shots)
 


### PR DESCRIPTION

**Description of the Change:**

It fixes a bug where we call `SparseHamiltonian` but it has no equivalent in ProjectQ. Then we remove `SparseHamiltonian` from possible observables in tests.

