### PR TITLE
Fix `SparseHamiltonian`bug, remove Python 3.6 and add Python 3.9

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-* Remove Python 3.6 and add the compatibility tag for Python 3.9.
+* Remove Python 3.5 / 3.6 and add the compatibility tag for Python 3.8 / 3.9.
   [(#72)](https://github.com/XanaduAI/pennylane-pq/pull/72)
 
 ### Improvements

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,15 +4,23 @@
 
 ### Breaking changes
 
+* Remove Python 3.6 and add the compatibility tag for Python 3.9.
+  [(#72)](https://github.com/XanaduAI/pennylane-pq/pull/72)
+
 ### Improvements
 
 ### Documentation
 
 ### Bug fixes
 
+* Remove `SparseHamiltonian` from possible observables in tests.
+  [(#72)](https://github.com/XanaduAI/pennylane-pq/pull/72)
+  
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Romain Moyard
 
 ---
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,9 @@ classifiers = [  # pylint: disable=invalid-name
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -121,10 +121,9 @@ class CompareWithDefaultQubitTest(BaseTest):
                                 observable_pars = [np.array([[1,1j],[-1j,0]])]
                             else:
                                 raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the observable '+observable+" with par_domain="+str(observable_class.par_domain))
-                        elif observable_class.par_domain is None:
+                        elif str(observable) == "SparseHamiltonian":
                             raise IgnoreOperationException(
-                                'Skipping in automatic test because' + observable + " with par_domain=" + str(
-                                    observable_class.par_domain) + 'is not valid in ProjectQ.')
+                                'Skipping in automatic test because' + observable + 'is not valid in ProjectQ.')
                         else:
                             observable_pars = {}
 

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -121,6 +121,10 @@ class CompareWithDefaultQubitTest(BaseTest):
                                 observable_pars = [np.array([[1,1j],[-1j,0]])]
                             else:
                                 raise IgnoreOperationException('Skipping in automatic test because I don\'t know how to generate parameters for the observable '+observable+" with par_domain="+str(observable_class.par_domain))
+                        elif observable_class.par_domain is None:
+                            raise IgnoreOperationException(
+                                'Skipping in automatic test because' + observable + " with par_domain=" + str(
+                                    observable_class.par_domain) + 'is not valid in ProjectQ.')
                         else:
                             observable_pars = {}
 


### PR DESCRIPTION
**Description of the Change:**

It fixes a bug where we call SparseHamiltonian but it has no equivalent in ProjectQ. Then we remove SparseHamiltonian from possible observables in tests. It also remove Python 3.6 from the test suite and add Python 3.9.

