### PR TITLE
Fix PennyLaneAI repo links

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,13 +21,13 @@ This release contains contributions from (in alphabetical order):
 ### Breaking changes
 
 * Remove Python 3.5 / 3.6 and add the compatibility tag for Python 3.8 / 3.9.
-  [(#72)](https://github.com/XanaduAI/pennylane-pq/pull/72)
-  
+  [(#72)](https://github.com/PennyLaneAI/pennylane-pq/pull/72)
+
 ### Bug fixes
 
 * Remove `SparseHamiltonian` from authorized observables in tests.
-  [(#72)](https://github.com/XanaduAI/pennylane-pq/pull/72)
-  
+  [(#72)](https://github.com/PennyLaneAI/pennylane-pq/pull/72)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
@@ -43,7 +43,7 @@ Romain Moyard
 * For compatibility with PennyLane v0.15, the `analytic` keyword argument
   has been removed from all devices. Analytic expectation values can
   still be computed by setting `shots=None`.
-  [(#69)](https://github.com/XanaduAI/pennylane-pq/pull/69)
+  [(#69)](https://github.com/PennyLaneAI/pennylane-pq/pull/69)
 
 ### Contributors
 
@@ -58,7 +58,7 @@ Josh Izaac
 ### Improvements
 
 * The PennyLane-PQ plugin now supports ProjectQ v0.5.1
-  [(#62)](https://github.com/XanaduAI/pennylane-pq/pull/62)
+  [(#62)](https://github.com/PennyLaneAI/pennylane-pq/pull/62)
 
 * Updates the device to support lists of custom wire labels.
   [(#65)](https://github.com/PennyLaneAI/pennylane-pq/pull/65)
@@ -67,12 +67,12 @@ Josh Izaac
 
 * The documentation theme has been updated, and the documentation structure
   reorganized.
-  [(#60)](https://github.com/XanaduAI/pennylane-pq/pull/60)
+  [(#60)](https://github.com/PennyLaneAI/pennylane-pq/pull/60)
 
 ### Bug fixes
 
 * Updated the plugin to use the latest IBMQBackend from ProjectQ.
-  [(#62)](https://github.com/XanaduAI/pennylane-pq/pull/62)
+  [(#62)](https://github.com/PennyLaneAI/pennylane-pq/pull/62)
 
 ### Contributors
 
@@ -87,7 +87,7 @@ Josh Izaac, Maria Schuld
 ### Bug fixes
 
 * Adding the 'model': 'qubit' entry into the capabilities dictionary. Adjusting tests that previously used CV operators to use custom created operators.
-  ([#56](https://github.com/XanaduAI/pennylane-pq/pull/56))
+  ([#56](https://github.com/PennyLaneAI/pennylane-pq/pull/56))
 
 ### Contributors
 
@@ -104,7 +104,7 @@ Antal Szava
 * The way measurement statistics works has changed in the latest version of PennyLane. Now, rather
   than `shots=0` referring to 'analytic' mode, there is a separate analytic argument.
   Further, the num_shots argument has been removed from Device.samples().
-  ([#53](https://github.com/XanaduAI/pennylane-pq/pull/53))
+  ([#53](https://github.com/PennyLaneAI/pennylane-pq/pull/53))
 
 ### Contributors
 
@@ -119,7 +119,7 @@ Josh Izaac
 ### Bug fixes
 
 * Remove opening of `requirements.txt` from within `setup.py`. This avoids a `FileNotFoundError` if installing via `pip`, as Python renames this file during packaging to `requires.txt`.
-  ([#53](https://github.com/XanaduAI/pennylane-pq/pull/53))
+  ([#53](https://github.com/PennyLaneAI/pennylane-pq/pull/53))
 
 ### Contributors
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@ If you want to contribute but don't know where to start, start by checking out t
 and having a look at the PennyLane API and code documentation to see how things work under the hood.
 
 Finally, check out the contributing guidelines in the main
-[PennyLane repository](https://github.com/XanaduAI/pennylane/blob/master/.github/CONTRIBUTING.md).
+[PennyLane repository](https://github.com/PennyLaneAI/pennylane/blob/master/.github/CONTRIBUTING.md).
 
 If you are interested in contributing to the PennyLane-PQ plugin directly, continue reading below.
 
@@ -37,7 +37,7 @@ and submitting pull requests.
 
 ## Reporting bugs
 
-We use the [GitHub issue tracker](https://github.com/XanaduAI/pennylane-sf/issues) to keep track of all reported
+We use the [GitHub issue tracker](https://github.com/PennyLaneAI/pennylane-sf/issues) to keep track of all reported
 bugs and issues. If you find a bug, or have an issue with PennyLane-PQ, please submit a bug report! User
 reports help us make PennyLane better on all fronts.
 
@@ -109,13 +109,11 @@ Before submitting a pull request, please make sure the following is done:
 
 * Once you have submitted the pull request, three things will automatically occur:
 
-  - The **test suite** will automatically run on [Travis CI](https://travis-ci.org/XanaduAI/pennylane)
-    to ensure that the all tests continue to pass.
+  - The **test suite** will automatically run to ensure that the all tests continue to pass.
   - Once the test suite is finished, a **code coverage report** will be generated on
-    [Codecov](https://codecov.io/gh/XanaduAI/pennylane). This will calculate the percentage of PennyLane
+    [Codecov](https://codecov.io/gh/PennyLaneAI/pennylane). This will calculate the percentage of PennyLane
     covered by the test suite, to ensure that all new code additions are adequately tested.
-  - Finally, the **code quality** is calculated by [Codacy](https://app.codacy.com/app/XanaduAI/pennylane/dashboard),
-    to ensure all new code additions adhere to our code quality standards.
+  - Finally, the **code quality** is calculated to ensure all new code additions adhere to our code quality standards.
 
   Based on these reports, we may ask you to make small changes to your branch before merging the pull request into the master branch. Alternatively, you can also
   [grant us permission to make changes to your pull request branch](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,7 +37,7 @@ and submitting pull requests.
 
 ## Reporting bugs
 
-We use the [GitHub issue tracker](https://github.com/PennyLaneAI/pennylane-sf/issues) to keep track of all reported
+We use the [GitHub issue tracker](https://github.com/PennyLaneAI/pennylane-pq/issues) to keep track of all reported
 bugs and issues. If you find a bug, or have an issue with PennyLane-PQ, please submit a bug report! User
 reports help us make PennyLane better on all fronts.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -31,7 +31,7 @@ Description of the issue - include code snippets and screenshots here if relevan
 
 * **PennyLane-PQ version:**
   This can be found by running
-  python -c "import pennylane_sf as sf; print(sf.version())"
+  python -c "import pennylane_pq as pq; print(pq.__version__)"
 
 * **Python version:**
   This can be found by running: python --version

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,14 +1,14 @@
 #### Before posting an issue
 
 Search existing GitHub issues to make sure the issue does not already exist:
-  https://github.com/xanaduai/pennylane-sf/issues
+  https://github.com/PennyLaneAI/pennylane-pq/issues
 
 If posting a PennyLane-PQ issue, delete everything above the dashed line, and fill in the template.
 
 If making a feature request, delete the following template and describe, in detail, the feature and why it is needed.
 
 For general technical details:
-* Check out our documentation: https://pennylane-sf.readthedocs.io
+* Check out our documentation: https://pennylane-pq.readthedocs.io
 
 -----------------------------------------------------------------------------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -236,7 +236,7 @@ html_theme_options = {
     # "index_template": "special_index.html",
 
     # Set the name of the project to appear in the left sidebar.
-    "project_nav_name": "PennyLane-Cirq",
+    "project_nav_name": "PennyLane-ProjectQ",
 
     # Set your Disqus short name to enable comments
     # "disqus_comments_shortname": "pennylane-1",
@@ -267,12 +267,12 @@ html_theme_options = {
     "table_header_border": "#19b37b",
     "download_button": "#19b37b",
     # gallery options
-    # "github_repo": "XanaduAI/PennyLane",
+    # "github_repo": "PennyLaneAI/PennyLane",
     # "gallery_dirs": "tutorials",
 }
 
-edit_on_github_project = 'XanaduAI/pennylane-cirq'
-edit_on_github_branch = 'master/doc'
+edit_on_github_project = "PennyLaneAI/pennylane-pq"
+edit_on_github_branch = "master/doc"
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/doc/xanadu_theme/footer.html
+++ b/doc/xanadu_theme/footer.html
@@ -14,7 +14,7 @@
           <hr width=100px class="d-inline-block mt-0 mb-1 Deep-purple accent-4">
           <ul class="list-unstyled">
             <li><a class="" href="https://pennylane.ai/">Home page</a></li>
-            <li><a class="" href="https://github.com/XanaduAI/pennylane">GitHub</a></li>
+            <li><a class="" href="https://github.com/PennyLaneAI/pennylane">GitHub</a></li>
             <li><a class="" href="https://pennylane.readthedocs.io/">Documentation</a></li>
             <li><a class="" href="https://discuss.pennylane.ai/">Discussion forum</a></li>
             <li><a class="" href="https://twitter.com/pennylaneai/">Twitter</a></li>

--- a/doc/xanadu_theme/header.html
+++ b/doc/xanadu_theme/header.html
@@ -56,7 +56,7 @@
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/XanaduAI/pennyLane-pq">
+        <a class="nav-link" href="https://github.com/PennyLaneAI/pennyLane-pq">
           <i class="fab fa-github"></i> GitHub
         </a>
       </li>

--- a/doc/xanadu_theme/layout.html
+++ b/doc/xanadu_theme/layout.html
@@ -285,7 +285,7 @@ if (downloadNote.length >= 1) {
     var tutorialUrlArray = $("#tutorial-type").text().split('/');
         tutorialUrlArray[0] = "examples"
 
-    var githubLink = "https://github.com/XanaduAI/pennylane/blob/master/" + tutorialUrlArray.join("/") + ".py",
+    var githubLink = "https://github.com/PennyLaneAI/pennylane/blob/master/" + tutorialUrlArray.join("/") + ".py",
         pythonLink = $(".reference.download")[0].href,
         notebookLink = $(".reference.download")[1].href,
         notebookDownloadPath = notebookLink.split('_downloads')[1].split('/').pop();

--- a/pennylane_pq/ops.py
+++ b/pennylane_pq/ops.py
@@ -79,7 +79,7 @@ class SqrtSwap(plops.Operation):  # pylint: disable=too-few-public-methods
 #     .. math:: AllPauliZ = \sigma_z \otimes\dots\otimes \sigma_z
 
 #     .. todo:: Potentially remove this gate depending on how
-#               https://github.com/XanaduAI/pennylane/issues/61 is resolved.
+#               https://github.com/PennyLaneAI/pennylane/issues/61 is resolved.
 
 #     """
 #     num_params = 0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ info = {  # pylint: disable=invalid-name
     "version": version,
     "maintainer": "Xanadu Inc.",
     "maintainer_email": "software@xanadu.ai",
-    "url": "https://github.com/XanaduAI/PennyLane-PQ",
+    "url": "https://github.com/PennyLaneAI/PennyLane-PQ",
     "license": "Apache License 2.0",
     "packages": ["pennylane_pq"],
     "entry_points": {


### PR DESCRIPTION
Includes other fixes for broken links (travis CI/codacy) or wrong descriptors (sf/cirq instead of pq).
