### PR TITLE
remove python 3.7 support; changelog updates; use pip for readthedocs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,18 +1,19 @@
-# Release 0.18.0-dev
-
-### New features since last release
-
-### Breaking changes
+# Release 0.29.0
 
 ### Improvements
 
-### Documentation
+* Update and simplify tests comparing with default.qubit to be compatible with
+  a more recent version of PennyLane.
+  [(#75)](https://github.com/PennyLaneAI/pennylane-pq/pull/75)
 
-### Bug fixes
+* Use the S an T gates provided by PennyLane instead of custom gates defined by the plugin.
+  [(#75)](https://github.com/PennyLaneAI/pennylane-pq/pull/75)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Romain Moyard
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Release 0.29.0
+# Release 0.18.0-dev
+
+### New features since last release
 
 ### Breaking changes
 
@@ -13,6 +15,10 @@
 
 * Use the S an T gates provided by PennyLane instead of custom gates defined by the plugin.
   [(#75)](https://github.com/PennyLaneAI/pennylane-pq/pull/75)
+
+### Documentation
+
+### Bug fixes
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release 0.29.0
 
+### Breaking changes
+
+* Remove python 3.7 support.
+  [(#81)](https://github.com/PennyLaneAI/pennylane-pq/pull/81)
+
 ### Improvements
 
 * Update and simplify tests comparing with default.qubit to be compatible with

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10']
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Build and install Plugin
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ sphinx:
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
-  - none
+  - htmlzip
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,29 @@
-requirements_file: doc/requirements.txt
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - none
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.8
+  install:
+    - requirements: doc/requirements.txt
+    - method: pip
+      path: .
 
 build:
-    image: latest
-
-python:
-    version: 3.8
-
-# Don't build any extra formats
-formats:
-    - none
+  image: latest

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,5 +4,6 @@ ipykernel
 nbsphinx
 pygments-github-lexers
 pybind11
+setuptools-scm
 sphinx-automodapi
 pennylane-sphinx-theme

--- a/pennylane_pq/_version.py
+++ b/pennylane_pq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.18.0-dev"
+__version__ = "0.29.0"

--- a/pennylane_pq/_version.py
+++ b/pennylane_pq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0"
+__version__ = "0.18.0-dev"

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -553,7 +553,6 @@ class ProjectQIBMBackend(_ProjectQDevice):
         probabilities = self._eng.backend.get_probabilities(self._reg)
 
         if observable in ["PauliX", "PauliY", "PauliZ", "Hadamard"]:
-
             if observable != "PauliZ" and not hasattr(self, "obs_queue"):
                 raise DeviceError(
                     "Measurements in basis other than PauliZ are only supported when "

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ classifiers = [  # pylint: disable=invalid-name
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3 :: Only",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("pennylane_pq/_version.py") as f:
 
 
 requirements = [
-    "projectq>=0.5.1,<0.8.0",
+    "projectq>=0.5.1",
     "pennylane>=0.15"
 ]  # pylint: disable=invalid-name
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("pennylane_pq/_version.py") as f:
 
 
 requirements = [
-    "projectq>=0.5.1",
+    "projectq>=0.5.1,<0.8.0",
     "pennylane>=0.15"
 ]  # pylint: disable=invalid-name
 


### PR DESCRIPTION
this PR does 3 things:
- remove 3.7 support
- add changelog entries
- use pip instead of setuptools for the ReadTheDocs build. it fails tragically when installing the latest ProjectQ (>=0.8.0) with setuptools, ReadTheDocs recommends using pip, and we use it in our other repos, so it makes sense.

note: there are no CI actions available for this repo, so I made the necessary changes manually. I will get those prepared before the 0.30 release