### PR TITLE
remove outdated test

### DIFF
--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -91,7 +91,7 @@ class BasisStateTest(BaseTest):
             return
         self.logTestName()
 
-        if int(qml.__version__[3]) < 3:
+        if int(qml.__version__[3]) < 2:
             self.skipTest("mid circuit measurements not yet supported.")
 
         for device in self.devices:

--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -91,7 +91,11 @@ class BasisStateTest(BaseTest):
             return
         self.logTestName()
 
+        if int(qml.__version__[3]) < 3:
+            self.skipTest("mid circuit measurements not yet supported.")
+
         for device in self.devices:
+
             @qml.qnode(device)
             def circuit():
                 qml.PauliX(wires=[0])

--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -86,6 +86,20 @@ class BasisStateTest(BaseTest):
 
                 self.assertAllAlmostEqual([1]*(self.num_subsystems-1)-2*bits_to_flip, np.array(circuit()[:-1]), delta=self.tol)
 
+    def test_basis_state_after_other_operation(self):
+        if self.devices is None:
+            return
+        self.logTestName()
+
+        for device in self.devices:
+            @qml.qnode(device)
+            def circuit():
+                qml.PauliX(wires=[0])
+                qml.BasisState(np.array([1, 1, 0, 1]), wires=list(range(self.num_subsystems)))
+                return qml.expval(qml.PauliZ(1))
+
+            assert qml.math.allclose(circuit(), 1)
+
 
 if __name__ == '__main__':
     print('Testing PennyLane ProjectQ Plugin version ' + qml.version() + ', BasisState operation.')

--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -86,20 +86,6 @@ class BasisStateTest(BaseTest):
 
                 self.assertAllAlmostEqual([1]*(self.num_subsystems-1)-2*bits_to_flip, np.array(circuit()[:-1]), delta=self.tol)
 
-    def test_disallow_basis_state_after_other_operation(self):
-        if self.devices is None:
-            return
-        self.logTestName()
-
-        for device in self.devices:
-            @qml.qnode(device)
-            def circuit():
-                qml.PauliX(wires=[0])
-                qml.BasisState(np.array([0, 1, 0, 1]), wires=list(range(self.num_subsystems)))
-                return qml.expval(qml.PauliZ(0))
-
-            self.assertRaises(ValueError, circuit)
-
 
 if __name__ == '__main__':
     print('Testing PennyLane ProjectQ Plugin version ' + qml.version() + ', BasisState operation.')

--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -96,7 +96,7 @@ class BasisStateTest(BaseTest):
             def circuit():
                 qml.PauliX(wires=[0])
                 qml.BasisState(np.array([1, 1, 0, 1]), wires=list(range(self.num_subsystems)))
-                return qml.expval(qml.PauliZ(1))
+                return qml.expval(qml.PauliZ(0))
 
             assert qml.math.allclose(circuit(), 1)
 


### PR DESCRIPTION
There was a test that was checking that you couldn't have a state prep after another operation. Now we can have state preps after other operations. So we are removing that test.