### PR TITLE
sunset the ProjectQ plugin

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,20 +1,15 @@
-# Release 0.34.0-dev
-
-### New features since last release
-
-### Improvements 🛠
+# Release 0.34.0
 
 ### Breaking changes 💔
 
-### Deprecations 👋
-
-### Documentation 📝
-
-### Bug fixes 🐛
+* Pin the PennyLane version to <0.34
+  [(#98)](https://github.com/PennyLaneAI/pennylane-pq/pull/98)
 
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Matthew Silverman
 
 ---
 # Release 0.33.0

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes 💔
 
-* Pin the PennyLane version to <0.34
+* Pin the PennyLane version to <0.35
   [(#98)](https://github.com/PennyLaneAI/pennylane-pq/pull/98)
 
 ### Contributors ✍️

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,11 @@ PennyLane ProjectQ Plugin
     :alt: PyPI - Python Version
     :target: https://pypi.org/project/PennyLane-pq
 
+\
+
+    **❗ This plugin will not be supported in newer versions of PennyLane. It is compatible with versions
+    of PennyLane up to and including 0.34❗**
+
 .. header-start-inclusion-marker-do-not-remove
 
 The PennyLane-ProjectQ plugin integrates the ProjectQ quantum computing library with PennyLane's

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,6 +3,11 @@ PennyLane-ProjectQ Plugin
 
 :Release: |release|
 
+.. warning::
+
+    This plugin will not be supported in newer versions of PennyLane. It is compatible with versions
+    of PennyLane up to and including 0.34.
+
 .. image:: _static/puzzle_pq.png
     :align: center
     :width: 70%

--- a/pennylane_pq/_version.py
+++ b/pennylane_pq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.34.0-dev"
+__version__ = "0.34.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 projectq>=0.5.1
-pennylane>=0.15
+pennylane>=0.15,<0.35
 pybind11

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("pennylane_pq/_version.py") as f:
 
 requirements = [
     "projectq>=0.5.1",
-    "pennylane>=0.15"
+    "pennylane>=0.15,<0.35"
 ]  # pylint: disable=invalid-name
 
 


### PR DESCRIPTION
as the title says. I'm matching the format used when sunsetting the orquestra plugin

do we want to get a token of some sort to prove that it works before sunsetting?

[sc-51706]

for posterity: tests requiring IBMQ access are failing because of a projectq [implementation detail](https://github.com/ProjectQ-Framework/ProjectQ/blob/dad48c59e0a7f4c114b5885a38439e7774698b39/projectq/backends/_ibm/_ibm_http_client.py#L18-L20)